### PR TITLE
Add information about Python port

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Please see http://nickzeeb.wordpress.com/2013/03/07/the-coalescing-ring-buffer/ 
 
 Ports:
 ==========
-.Net https://github.com/ncornwell/NCoalescingRingBuffer
+* .Net https://github.com/ncornwell/NCoalescingRingBuffer
+* Python https://github.com/jstasiak/coalringbuf
 
 Changelog
 ==========


### PR DESCRIPTION
Hi!

First of all - thanks for the blog post (http://nickzeeb.wordpress.com/2013/03/07/the-coalescing-ring-buffer/), it was informative and it got me interested enough so here's a straightforward Python port of CoalescingRingBuffer. There are some things I'd like to change in it but it's feature complete. (still not sure about the module name, I was thinking about coalescingringbuffer but it's a bit too long to my taste)

BTW, have you managed to eliminate the issue with the consumer seeing some duplicated values? Or do you have some details about this issue, when does it happen etc.?

Cheers
