### PR TITLE
Few small pom changes.

### DIFF
--- a/CoalescingRingBuffer-samples/pom.xml
+++ b/CoalescingRingBuffer-samples/pom.xml
@@ -6,12 +6,11 @@
     <parent>
         <groupId>com.lmax.collections</groupId>
         <artifactId>collections-parent</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>coalescingringbuffer-samples</artifactId>
-    <version>1.0.0</version>
     <description>Samples of using CoalescingRingBuffer</description>
     <url>https://github.com/LMAX-Exchange/LMAXCollections/CoalescingRingBuffer-samples</url>
 
@@ -19,7 +18,7 @@
         <dependency>
             <groupId>com.lmax.collections</groupId>
             <artifactId>coalescingringbuffer</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0</version>
         </dependency>
     </dependencies>
 

--- a/CoalescingRingBuffer/pom.xml
+++ b/CoalescingRingBuffer/pom.xml
@@ -11,7 +11,6 @@
     </parent>
 
     <artifactId>coalescingringbuffer</artifactId>
-    <version>1.1.0</version>
     <description>Efficient buffer for storing only latest value/message for given topic</description>
     <url>https://github.com/LMAX-Exchange/LMAXCollections/CoalescingRingBuffer</url>
 


### PR DESCRIPTION
1) Bump version of parent to 1.1.0 from 1.0.0 in the samples pom.xml
2) Remove project explicit version numbers and instead derive from parent version numbers
3) Bump dependency version in samples from 1.0.0 to 1.1.0
